### PR TITLE
feat(depencenies): ⌚ Add PSR Clock interface as dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     ],
     "require": {
         "php": "^7.4 || ~8.0 || ~8.1",
+        "psr/clock": "^1.0",
         "psr/container": "^1.1.1",
         "psr/event-dispatcher": "^1.0",
         "psr/log": "^1.1"


### PR DESCRIPTION
To not cause issues on the OCP interface extending PSR, similar to the logger
Ref: https://github.com/nextcloud/3rdparty/pull/1262